### PR TITLE
verify.c: Remove redundant conditional

### DIFF
--- a/src/cli/verify.c
+++ b/src/cli/verify.c
@@ -90,7 +90,7 @@ int verify(const char *command, int argc, char **argv) {
 
   ecc_int256_t hash;
 
-  if (!sha256_file((optind <= argc) ? argv[optind] : NULL, hash.p)) {
+  if (!sha256_file(argv[optind], hash.p)) {
     fprintf(stderr, "Error while hashing file\n");
     goto out;
   }


### PR DESCRIPTION
Line 86 already ensures that `optind > argc`, no need to check for `optind <= argc` a few lines later.